### PR TITLE
Add auto port if only domain is given

### DIFF
--- a/check-ssl-heartbleed.pl
+++ b/check-ssl-heartbleed.pl
@@ -88,6 +88,8 @@ if (@show_regex) {
 }
 
 my $dst = shift(@ARGV) or usage("no destination given");
+# auto add HTTPS port if not existing
+$dst .= ':443' if ($dst !~ /:\w+/);
 my $cl = IO::Socket::INET->new(PeerAddr => $dst, Timeout => $timeout)
     or die "failed to connect: $!";
 $starttls->($cl);


### PR DESCRIPTION
If the command line missed :<port> it will automatically add :443 so it
does a default check on HTTPS
