### PR TITLE
Use index variable for $ip

### DIFF
--- a/analyze-ssl.pl
+++ b/analyze-ssl.pl
@@ -198,11 +198,13 @@ for my $test (@tests) {
     my $tcp_connect = sub {
 	my $use_ip = shift;
 	my $tries = 1;
+        my $ip_index = 0;
+        my $ip_index_max = @ip - 1;
 
 	TRY_IP:
 	my ($cl,$error);
 	my %ioargs = (
-	    PeerAddr => $use_ip || $ip[0],
+	    PeerAddr => $use_ip || $ip[$ip_index],
 	    PeerPort => $port,
 	    Timeout => $timeout,
 	);
@@ -217,10 +219,11 @@ for my $test (@tests) {
 		$error = "tcp connect: $!";
 	    }
 	}
-	if ($error && ! $use_ip && @ip>1) {
+	if ($error && ! $use_ip && @ip>1 && $ip_index < $ip_index_max) {
 	    # retry with next IP
-	    VERBOSE(1,"$ip[0] failed permanently, trying next");
-	    push @problems, "failed tcp connect to $ip[0]";
+	    VERBOSE(1,"$ip[$ip_index] failed permanently, trying next");
+	    push @problems, "failed tcp connect to $ip[$ip_index]";
+	    $ip_index = $ip_index + 1;
 	    goto TRY_IP;
 	}
 	$cl or die $error;


### PR DESCRIPTION
I haven't done any perl programming in over a decade, so the code style here is probably horrible.

On my system, shift doesn't work so when testing http_upgrade I ended up in an infinite loop where it kept trying $ip[0] over and over.

I added an index variable so it can loop, and a check for the max ip numbers.

One problem I don't know how to fix is that if the array of ip addresses has an ipv6 address in it, this loop will eventually fail.  Example:
./analyze-ssl.pl  --starttls http_upgrade www.google.com:80

I either get one ipv4 address and one ipv6 - or I get 4 ipv4 addresses and one ipv6.

The ipv4 addresses work perfectly and it loops fine, when it reaches the ipv6 address it dies.  Adding a check to see if it is ipv6 at line 206 and skipping to the next loop would be good - I just don't know how.  

In any case, thanks for the great utility! I was able to very quickly verify what I wanted to know[that google does not support starttls in http sessions] and I can move on to other projects.  I figured I'd send back my semi functional fix in case it helps anyone else - but since I focus on PHP development I didn't take the time to figure out how to fix the other half of the bug - sorry. 