### PR TITLE
use /usr/bin/env to locate perl executable

### DIFF
--- a/analyze-ssl.pl
+++ b/analyze-ssl.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Copyright 2013..2015 Steffen Ullrich <sullr@cpan.org>
 #   This program is free software; you can redistribute it and/or

--- a/check-ssl-heartbleed.pl
+++ b/check-ssl-heartbleed.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # Copyright: Steffen Ullrich 2014
 # Public Domain: feel free to use, copy, modify without restrictions - NO WARRANTY
 

--- a/https_ocsp_bulk.pl
+++ b/https_ocsp_bulk.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # Copyright 2014 Steffen Ullrich <sullr@cpan.org>
 #   This program is free software; you can redistribute it and/or
 #   modify it under the same terms as Perl itself.

--- a/mx_starttls_bulk-summarize.pl
+++ b/mx_starttls_bulk-summarize.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # Copyright 2014 Steffen Ullrich <sullr@cpan.org>
 #   This program is free software; you can redistribute it and/or
 #   modify it under the same terms as Perl itself.

--- a/mx_starttls_bulk.pl
+++ b/mx_starttls_bulk.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # Copyright 2014 Steffen Ullrich <sullr@cpan.org>
 #   This program is free software; you can redistribute it and/or
 #   modify it under the same terms as Perl itself.


### PR DESCRIPTION
Utilize `#!/usr/bin/env perl` to use whatever perl executable appears first in the user's $PATH. This is needed for local or overlayed installations like HomeBrew or MacPorts.